### PR TITLE
fix/0001 - Turn off digest authentication and use basic instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /vendor/
 /.vagrant/
 /coverage.xml
+.idea

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,12 @@
     }
   ],
   "require": {
-    "php": "^7.2.5 || ^8.0",
+    "php": "^8.0",
     "ext-xml": "*",
     "guzzlehttp/guzzle": "^7.0",
     "psr/http-message": "^1.0",
-    "ramsey/uuid": "^3.8"
+    "ramsey/uuid": "^3.8",
+    "ext-mbstring": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^8",

--- a/src/phoneid/PhoneIdClient.php
+++ b/src/phoneid/PhoneIdClient.php
@@ -22,31 +22,4 @@ class PhoneIdClient extends RestClient {
   function phoneid ($phone_number, array $fields = []) {
     return $this->post(sprintf(self::PHONEID_RESOURCE, $phone_number), $fields);
   }
-  
-  protected function execute ($method_name, $resource, $fields = [], $date = null, $nonce = null) {
-    $json_fields = json_encode($fields, JSON_FORCE_OBJECT);
-    
-    $content_type = in_array($method_name, ["POST", "PUT"]) ? "application/json" : "";
-    
-    $headers = $this->generateTelesignHeaders(
-      $this->customer_id,
-      $this->api_key,
-      $method_name,
-      $resource,
-      $json_fields,
-      $date,
-      $nonce,
-      $this->user_agent,
-      $content_type
-    );
-
-    $option = in_array($method_name, [ "POST", "PUT" ]) ? "body" : "query";
-
-    return new Response($this->client->request($method_name, $resource, [
-      "headers" => $headers,
-      $option => in_array($method_name, [ "POST", "PUT"]) ? $json_fields : $fields,
-      "http_errors" => false
-    ]));
-  }
-
 }


### PR DESCRIPTION
Turning off digest authentication as it doesn't seem to be working with the new verify API